### PR TITLE
Adiciona exemplos de utilização do dialogs.menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,31 @@ dialog.confirm({
 });
 ```
 
+3. Menu
+
+```js 
+dialog.menu('Title', 
+	[
+		{
+			value: '1',
+			label: 'Opção 1'
+		},
+
+		{
+			value: '2',
+			label: 'Opção 2'
+		}
+	], 
+
+	function (e) {
+		var value = $(e.currentTarget).data('value');
+
+		alert("Callback ao clicar na opção de valor " + value);
+	}
+);
+```
+
+
 ## Contributing
 
 1. Fork it!

--- a/demo/cmd.js
+++ b/demo/cmd.js
@@ -23,4 +23,26 @@ $(function() {
 			}
 		});
 	});
+
+	$('[name="menu"]').click(function () {
+		dialog.menu('Title',
+			[
+				{
+					value: '1',
+					label: 'Opção 1'
+				},
+
+				{
+					value: '2',
+					label: 'Opção 2'
+				}
+			],
+
+			function (e) {
+				var value = $(e.currentTarget).data('value');
+
+				alert("Callback ao clicar na opção de valor " + value);
+			}
+		);
+	});
 });

--- a/demo/index.html
+++ b/demo/index.html
@@ -14,6 +14,7 @@
 		<div class="">
 			<button type="button" name="info">Teste o dialog info</button>
 			<button type="button" name="confirm">Teste o dialog confirm</button>
+			<button type="button" name="menu">Teste o dialog menu</button>
 		</div>
 
 	</body>


### PR DESCRIPTION
os exemplos são adicionados ao `README.md`, bem como à demonstração, na pasta `/demo`